### PR TITLE
Fix stop_time importer

### DIFF
--- a/gtfs2mongo.js
+++ b/gtfs2mongo.js
@@ -76,7 +76,7 @@ var fileMap = [
 	{'fName':'stops.txt','cName':'stops','uID':['stop_id']},
 	{'fName':'routes.txt','cName':'routes','uID':['route_id']},
 	{'fName':'trips.txt','cName':'trips','uID':['trip_id']},
-	{'fName':'stop_times.txt','cName':'stop_times','uID':['trip_id']},
+	{'fName':'stop_times.txt','cName':'stop_times','uID':['trip_id','stop_id']},
 	{'fName':'fare_attributes.txt','cName':'fare_attributes','uID':['fare_id']},
 	{'fName':'fare_rules.txt','cName':'fare_rules','uID':['fare_id']},
 	{'fName':'shapes.txt','cName':'shapes','uID':['shape_id','shape_pt_sequence']},


### PR DESCRIPTION
Importing stop-times.txt was only using the trip_id for the uID, this caused the script to create only a single stop time record for the first stop_time it found for a trip_id. This fix corrects this by adding 'stop_id' as a second uID to sto_times.txt in the fileMap. The script now correctly creates a record for each stoptime in stop_time.txt.